### PR TITLE
Add minimal FastAPI app

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+APP_ENV=production

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello, World!"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.108.0
+uvicorn==0.23.2


### PR DESCRIPTION
## Summary
- add FastAPI app skeleton in `app` package
- add `requirements.txt` and a sample `.env`
- add `.gitignore`

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: no files matched)*

------
https://chatgpt.com/codex/tasks/task_e_685024c02d4c8332a7221e5a8148e72c